### PR TITLE
Fully typed `RangeMap` and avoid complete iterations to find matches

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,3 +54,16 @@ nitpick_ignore += [
 nitpick_ignore += [
     ('py:class', 're.Pattern'),
 ]
+
+# jaraco/jaraco.collections#16
+nitpick_ignore += [
+    ('py:class', 'SupportsKeysAndGetItem'),
+    ('py:class', '_RangeMapKT'),
+    ('py:class', '_VT'),
+    ('py:class', '_T'),
+    ('py:class', 'jaraco.collections._RangeMapKT'),
+    ('py:class', 'jaraco.collections._VT'),
+    ('py:class', 'jaraco.collections._T'),
+    ('py:obj', 'jaraco.collections._RangeMapKT'),
+    ('py:obj', 'jaraco.collections._VT'),
+]

--- a/jaraco/collections/__init__.py
+++ b/jaraco/collections/__init__.py
@@ -19,12 +19,13 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     _RangeMapKT = TypeVar('_RangeMapKT', bound=_SupportsComparison)
+else:
+    # _SupportsComparison doesn't exist at runtime,
+    # but _RangeMapKT is used in RangeMap's superclass' type parameters
+    _RangeMapKT = TypeVar('_RangeMapKT')
 
 _T = TypeVar('_T')
 _VT = TypeVar('_VT')
-# _SupportsComparison doesn't exist at runtime,
-# but _RangeMapKT is used in RangeMap's superclass' type parameters
-_RangeMapKT = TypeVar('_RangeMapKT')
 
 _Matchable = Union[Callable, Container, Iterable, re.Pattern]
 

--- a/jaraco/collections/__init__.py
+++ b/jaraco/collections/__init__.py
@@ -267,7 +267,7 @@ class RangeMap(Dict[int, _VT]):
     undefined_value = type('RangeValueUndefined', (), {})()
 
     class Item(int):
-        'RangeMap Item'
+        """RangeMap Item"""
 
     first_item = Item(0)
     last_item = Item(-1)

--- a/jaraco/collections/__init__.py
+++ b/jaraco/collections/__init__.py
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
     from _typeshed import SupportsKeysAndGetItem
     from typing_extensions import Self
 
-_T = TypeVar("_T")
-_RangeMapKT = TypeVar("_RangeMapKT", bound=_SupportsComparison)
-_VT = TypeVar("_VT")
+_T = TypeVar('_T')
+_RangeMapKT = TypeVar('_RangeMapKT', bound=_SupportsComparison)
+_VT = TypeVar('_VT')
 
 _Matchable = Union[Callable, Container, Iterable, re.Pattern]
 
@@ -274,7 +274,7 @@ class RangeMap(Dict[_RangeMapKT, _VT]):
         return (sorted_keys[RangeMap.first_item], sorted_keys[RangeMap.last_item])
 
     # some special values for the RangeMap
-    undefined_value = type("RangeValueUndefined", (), {})()
+    undefined_value = type('RangeValueUndefined', (), {})()
 
     class Item(int):
         """RangeMap Item"""
@@ -531,7 +531,7 @@ class ItemsAsAttributes:
             # raise the original exception, but use the original class
             #  name, not 'super'.
             (message,) = e.args
-            message = message.replace("super", self.__class__.__name__, 1)
+            message = message.replace('super', self.__class__.__name__, 1)
             e.args = (message,)
             raise
 
@@ -554,7 +554,7 @@ def invert_map(map):
     """
     res = dict((v, k) for k, v in map.items())
     if not len(res) == len(map):
-        raise ValueError("Key conflict in inverted mapping")
+        raise ValueError('Key conflict in inverted mapping')
     return res
 
 
@@ -796,7 +796,7 @@ class FrozenDict(collections.abc.Mapping, collections.abc.Hashable):
     True
     """
 
-    __slots__ = ["__data"]
+    __slots__ = ['__data']
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
@@ -1024,7 +1024,7 @@ class FreezableDefaultDict(collections.defaultdict):  # type: ignore
     """
 
     def __missing__(self, key):
-        return getattr(self, "_frozen", super().__missing__)(key)
+        return getattr(self, '_frozen', super().__missing__)(key)
 
     def freeze(self):
         self._frozen = lambda key: self.default_factory()

--- a/jaraco/collections/__init__.py
+++ b/jaraco/collections/__init__.py
@@ -18,9 +18,13 @@ if TYPE_CHECKING:
     from _typeshed import SupportsKeysAndGetItem
     from typing_extensions import Self
 
+    _RangeMapKT = TypeVar('_RangeMapKT', bound=_SupportsComparison)
+
 _T = TypeVar('_T')
-_RangeMapKT = TypeVar('_RangeMapKT', bound=_SupportsComparison)
 _VT = TypeVar('_VT')
+# _SupportsComparison doesn't exist at runtime,
+# but _RangeMapKT is used in RangeMap's superclass' type parameters
+_RangeMapKT = TypeVar('_RangeMapKT')
 
 _Matchable = Union[Callable, Container, Iterable, re.Pattern]
 

--- a/jaraco/collections/__init__.py
+++ b/jaraco/collections/__init__.py
@@ -8,9 +8,16 @@ import operator
 import random
 import re
 from collections.abc import Container, Iterable, Mapping
-from typing import Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar, Union, overload
 
 import jaraco.text
+
+if TYPE_CHECKING:
+    from _typeshed import SupportsKeysAndGetItem
+    from typing_extensions import Self
+
+_T = TypeVar('_T')
+_VT = TypeVar('_VT')
 
 _Matchable = Union[Callable, Container, Iterable, re.Pattern]
 
@@ -119,7 +126,7 @@ def dict_map(function, dictionary):
     return dict((key, function(value)) for key, value in dictionary.items())
 
 
-class RangeMap(dict):
+class RangeMap(Dict[int, _VT]):
     """
     A dictionary-like object that uses the keys as bounds for a range.
     Inclusion of the value for that range is determined by the
@@ -186,7 +193,7 @@ class RangeMap(dict):
     which requires use of sort params and a key_match_comparator.
 
     >>> r = RangeMap({1: 'a', 4: 'b'},
-    ...     sort_params=dict(reverse=True),
+    ...     sort_params={'reverse': True},
     ...     key_match_comparator=operator.ge)
     >>> r[1], r[2], r[3], r[4], r[5], r[6]
     ('a', 'a', 'a', 'b', 'b', 'b')
@@ -202,21 +209,23 @@ class RangeMap(dict):
 
     def __init__(
         self,
-        source,
+        source: SupportsKeysAndGetItem[int, _VT] | Iterable[tuple[int, _VT]],
         sort_params: Mapping[str, Any] = {},
-        key_match_comparator=operator.le,
+        key_match_comparator: Callable[[int, int], bool] = operator.le,
     ):
         dict.__init__(self, source)
         self.sort_params = sort_params
         self.match = key_match_comparator
 
     @classmethod
-    def left(cls, source):
+    def left(
+        cls, source: SupportsKeysAndGetItem[int, _VT] | Iterable[tuple[int, _VT]]
+    ) -> Self:
         return cls(
-            source, sort_params=dict(reverse=True), key_match_comparator=operator.ge
+            source, sort_params={'reverse': True}, key_match_comparator=operator.ge
         )
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int) -> _VT:
         sorted_keys = sorted(self.keys(), **self.sort_params)
         if isinstance(item, RangeMap.Item):
             result = self.__getitem__(sorted_keys[item])
@@ -227,7 +236,11 @@ class RangeMap(dict):
                 raise KeyError(key)
         return result
 
-    def get(self, key, default=None):
+    @overload  # type: ignore[override] # Signature simplified over dict and Mapping
+    def get(self, key: int, default: _T) -> _VT | _T: ...
+    @overload
+    def get(self, key: int, default: None = None) -> _VT | None: ...
+    def get(self, key: int, default: _T | None = None) -> _VT | _T | None:
         """
         Return the value for key if key is in the dictionary, else default.
         If default is not given, it defaults to None, so that this method
@@ -238,14 +251,15 @@ class RangeMap(dict):
         except KeyError:
             return default
 
-    def _find_first_match_(self, keys, item):
+    def _find_first_match_(self, keys: Iterable[int], item: int) -> int:
         is_match = functools.partial(self.match, item)
-        matches = list(filter(is_match, keys))
-        if matches:
-            return matches[0]
-        raise KeyError(item)
+        matches = filter(is_match, keys)
+        try:
+            return next(matches)
+        except StopIteration:
+            raise KeyError(item) from None
 
-    def bounds(self):
+    def bounds(self) -> tuple[int, int]:
         sorted_keys = sorted(self.keys(), **self.sort_params)
         return (sorted_keys[RangeMap.first_item], sorted_keys[RangeMap.last_item])
 
@@ -253,7 +267,7 @@ class RangeMap(dict):
     undefined_value = type('RangeValueUndefined', (), {})()
 
     class Item(int):
-        "RangeMap Item"
+        'RangeMap Item'
 
     first_item = Item(0)
     last_item = Item(-1)

--- a/jaraco/collections/__init__.py
+++ b/jaraco/collections/__init__.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     from _typeshed import SupportsKeysAndGetItem
     from typing_extensions import Self
 
-_T = TypeVar('_T')
-_VT = TypeVar('_VT')
+_T = TypeVar("_T")
+_VT = TypeVar("_VT")
 
 _Matchable = Union[Callable, Container, Iterable, re.Pattern]
 
@@ -193,7 +193,7 @@ class RangeMap(Dict[int, _VT]):
     which requires use of sort params and a key_match_comparator.
 
     >>> r = RangeMap({1: 'a', 4: 'b'},
-    ...     sort_params={'reverse': True},
+    ...     sort_params=dict(reverse=True),
     ...     key_match_comparator=operator.ge)
     >>> r[1], r[2], r[3], r[4], r[5], r[6]
     ('a', 'a', 'a', 'b', 'b', 'b')
@@ -222,7 +222,7 @@ class RangeMap(Dict[int, _VT]):
         cls, source: SupportsKeysAndGetItem[int, _VT] | Iterable[tuple[int, _VT]]
     ) -> Self:
         return cls(
-            source, sort_params={'reverse': True}, key_match_comparator=operator.ge
+            source, sort_params=dict(reverse=True), key_match_comparator=operator.ge
         )
 
     def __getitem__(self, item: int) -> _VT:
@@ -264,7 +264,7 @@ class RangeMap(Dict[int, _VT]):
         return (sorted_keys[RangeMap.first_item], sorted_keys[RangeMap.last_item])
 
     # some special values for the RangeMap
-    undefined_value = type('RangeValueUndefined', (), {})()
+    undefined_value = type("RangeValueUndefined", (), {})()
 
     class Item(int):
         """RangeMap Item"""
@@ -521,7 +521,7 @@ class ItemsAsAttributes:
             # raise the original exception, but use the original class
             #  name, not 'super'.
             (message,) = e.args
-            message = message.replace('super', self.__class__.__name__, 1)
+            message = message.replace("super", self.__class__.__name__, 1)
             e.args = (message,)
             raise
 
@@ -544,7 +544,7 @@ def invert_map(map):
     """
     res = dict((v, k) for k, v in map.items())
     if not len(res) == len(map):
-        raise ValueError('Key conflict in inverted mapping')
+        raise ValueError("Key conflict in inverted mapping")
     return res
 
 
@@ -786,7 +786,7 @@ class FrozenDict(collections.abc.Mapping, collections.abc.Hashable):
     True
     """
 
-    __slots__ = ['__data']
+    __slots__ = ["__data"]
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
@@ -1014,7 +1014,7 @@ class FreezableDefaultDict(collections.defaultdict):  # type: ignore
     """
 
     def __missing__(self, key):
-        return getattr(self, '_frozen', super().__missing__)(key)
+        return getattr(self, "_frozen", super().__missing__)(key)
 
     def freeze(self):
         self._frozen = lambda key: self.default_factory()

--- a/newsfragments/16.feature.rst
+++ b/newsfragments/16.feature.rst
@@ -1,0 +1,1 @@
+Fully typed ``RangeMap`` and avoid complete iterations to find matches -- by :user:`Avasam`


### PR DESCRIPTION
Bringing improvements over from https://github.com/mhammond/pywin32/pull/2334

- Fully typed `RangeMap`
- Avoid complete iterations to find matches
- ~~Use dict literal instead of dict call https://docs.astral.sh/ruff/rules/unnecessary-collection-call/~~ see https://docs.astral.sh/ruff/settings/#lintflake8-comprehensions
